### PR TITLE
:gift_heart: ES Modules - check circular deps (fixes noref)

### DIFF
--- a/es-modules.js
+++ b/es-modules.js
@@ -4,7 +4,10 @@
     ES Modules config
 */
 module.exports = {
-    plugins: ['import'],
+    plugins: [
+        'dependencies',
+        'import',
+    ],
     extends: [
         'homezen/es-next',
         'plugin:import/errors',
@@ -13,6 +16,7 @@ module.exports = {
         sourceType: 'module',
     },
     rules: {
+        'dependencies/no-cycles': 2,
         'import/extensions': [2,
             'never',
             {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,14 @@
   "dependencies": {
     "eslint": "3.17.0",
     "eslint-import-resolver-webpack": "0.8.1",
+    "eslint-plugin-dependencies": "~2.2.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-lodash": "2.3.5",
     "eslint-plugin-lodash-fp": "^2.1.3",
     "eslint-plugin-react": "6.10.0"
+  },
+  "optionalDependencies": {
+    "webpack": "^2.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Check for circular deps in es-modules config
- Added optional dep of webpack to squelch peer dep warnings in
  consuming projects

release v+minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/homezen/eslint-config-homezen/8)
<!-- Reviewable:end -->
