### PR TITLE
:shower: eslint version consistency (fixes noref)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "eslint-plugin-react": "7.1.0"
   },
   "optionalDependencies": {
-    "webpack": "^3.0.0"
+    "webpack": "^3.1.0"
   },
   "peerDependencies": {
-    "eslint": "4.1.1"
+    "eslint": "^4.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- updated eslint peerdep version to
  - reflect regular dependency version
  - be more permissive, thus avoiding npm/yarn warnings